### PR TITLE
Remove reference to undefined pillar

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,11 +9,6 @@ transport:
 provisioner:
   name: dokken_salt
   formula: hello
-  pillars:
-    top.sls:
-      base:
-        '*':
-          - hello
   state_top:
     base:
       '*':


### PR DESCRIPTION
I noticed that this change did not take effect until I destroyed and converged the suite. Seems like kitchen-dokken-salt cached the provisioner configuration.